### PR TITLE
Put results after the selection

### DIFF
--- a/lib/execute-as-ruby.coffee
+++ b/lib/execute-as-ruby.coffee
@@ -17,8 +17,8 @@ module.exports =
             editor.insertText("\n" + result))
     else
         @runRuby(selection, (result) ->
-            editor.moveCursorToEndOfLine()
-            editor.insertText(" " + result))
+            cursor.moveRight({moveToEndOfSelection: true})
+            editor.insertText("\n" + result))
 
   packagePath: ->
     packagePath = null


### PR DESCRIPTION
When selecting from bottom to top, the results gets inserted after the end of the first line. This moves the cursor back to the end of the selection.
